### PR TITLE
Fix MacOS runner building x64 extension; macos-latest -> macos-13

### DIFF
--- a/.github/workflows/publish_vscode.yml
+++ b/.github/workflows/publish_vscode.yml
@@ -27,7 +27,7 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
             arch: armv7
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
             code-target: darwin-x64
           - os: macos-14


### PR DESCRIPTION
Fixes: #10 

This should now use an intel chip when installing Tach for the Mac x64 build.

Ref: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources