### PR TITLE
Auto-restart LSP when pyproject.toml, requirements.txt are changed anywhere

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -148,7 +148,7 @@ export async function restartServer(
         await newLSClient.start();
         _disposables.push(
             createConfigWatcher(
-                '**/{tach.toml,tach.domain.toml}',
+                '**/{tach.toml,tach.domain.toml,pyproject.toml,requirements.txt}',
                 serverId,
                 serverName,
                 outputChannel,


### PR DESCRIPTION
This PR improves the experience of the VSCode extension w.r.t. external diagnostics by automatically restarting the server when external dependency information may have changed. If you see a diagnostic indicating that a 3rd party dependency is undeclared, changing your dependencies in `pyproject.toml` or `requirements.txt` should dismiss that error.